### PR TITLE
Improve error message when Istio has not been installed on the cluster

### DIFF
--- a/src/main/java/me/snowdrop/cloud/fabric8/IstioEnricher.java
+++ b/src/main/java/me/snowdrop/cloud/fabric8/IstioEnricher.java
@@ -233,6 +233,11 @@ public class IstioEnricher extends BaseEnricher {
         final String configMapName = getConfig(Config.istioConfigMapName);
         ConfigMap map = kubeClient.configMaps().withName(configMapName).get();
 
+        if(map == null) {
+            throw new IllegalArgumentException("Couldn't find an ConfigMap named "
+                    + configMapName + " in namespace " + namespace + ". Are you sure Istio was installed correctly?");
+        }
+
         final YAMLMapper mapper = new YAMLMapper();
         final String meshConfigAsString = map.getData().get("mesh");
         if(meshConfigAsString != null) {


### PR DESCRIPTION
Prior to this commit when Istio was not installed on the cluster Maven
would fail with a NPE that would not provide much debugging context.