### PR TITLE
Remove fmp-project since it adds unnecessary labels and selectors

### DIFF
--- a/src/main/resources/META-INF/fabric8/profiles.yml
+++ b/src/main/resources/META-INF/fabric8/profiles.yml
@@ -7,7 +7,6 @@
     - fmp-image
     - fmp-portname
     - fmp-ianaservice
-    - fmp-project
     - fmp-dependency
     - fmp-pod-annotations
     - fmp-git


### PR DESCRIPTION
At best the labels are just superfluous, at worst they can cause
problems when it comes to matching services with pods

The code of the enricher can be found at: 

https://github.com/fabric8io/fabric8-maven-plugin/blob/v3.5.38/enricher/standard/src/main/java/io/fabric8/maven/enricher/standard/ProjectEnricher.java